### PR TITLE
typo in padding

### DIFF
--- a/mambavision/models/mamba_vision.py
+++ b/mambavision/models/mamba_vision.py
@@ -594,9 +594,8 @@ class MambaVisionLayer(nn.Module):
                 _, _, Hp, Wp = x.shape
             else:
                 Hp, Wp = H, W
-            Hp, Wp = H, W
             x = window_partition(x, self.window_size)
-
+            
         for _, blk in enumerate(self.blocks):
             x = blk(x)
         if self.transformer_block:


### PR DESCRIPTION
This PR addresses the issue with typo in padding which can hinder arbitrary resolution support. 

Addresses #63 and #56 issues. 