### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MambaVision: A Hybrid Mamba-Transformer Vision Backbone
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVlabs/MambaVision)
 
 Official PyTorch implementation of [**MambaVision: A Hybrid Mamba-Transformer Vision Backbone**](https://arxiv.org/abs/2407.08083).
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NVlabs/MambaVision) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.