### PR TITLE
Resolving conv_bias bug

### DIFF
--- a/mambavision/models/mamba_vision.py
+++ b/mambavision/models/mamba_vision.py
@@ -330,7 +330,7 @@ class MambaVisionMixer(nn.Module):
         dt_init="random",
         dt_scale=1.0,
         dt_init_floor=1e-4,
-        conv_bias=True,
+        conv_bias=False,
         bias=False,
         use_fast_path=True, 
         layer_idx=None,
@@ -381,7 +381,7 @@ class MambaVisionMixer(nn.Module):
         self.conv1d_x = nn.Conv1d(
             in_channels=self.d_inner//2,
             out_channels=self.d_inner//2,
-            bias=conv_bias//2,
+            bias=conv_bias,
             kernel_size=d_conv,
             groups=self.d_inner//2,
             **factory_kwargs,
@@ -389,7 +389,7 @@ class MambaVisionMixer(nn.Module):
         self.conv1d_z = nn.Conv1d(
             in_channels=self.d_inner//2,
             out_channels=self.d_inner//2,
-            bias=conv_bias//2,
+            bias=conv_bias,
             kernel_size=d_conv,
             groups=self.d_inner//2,
             **factory_kwargs,

--- a/object_detection/tools/mamba_vision.py
+++ b/object_detection/tools/mamba_vision.py
@@ -344,7 +344,7 @@ class MambaVisionMixer(nn.Module):
         dt_init="random",
         dt_scale=1.0,
         dt_init_floor=1e-4,
-        conv_bias=True,
+        conv_bias=False,
         bias=False,
         use_fast_path=True, 
         layer_idx=None,
@@ -395,7 +395,7 @@ class MambaVisionMixer(nn.Module):
         self.conv1d_x = nn.Conv1d(
             in_channels=self.d_inner//2,
             out_channels=self.d_inner//2,
-            bias=conv_bias//2,
+            bias=conv_bias,
             kernel_size=d_conv,
             groups=self.d_inner//2,
             **factory_kwargs,
@@ -403,7 +403,7 @@ class MambaVisionMixer(nn.Module):
         self.conv1d_z = nn.Conv1d(
             in_channels=self.d_inner//2,
             out_channels=self.d_inner//2,
-            bias=conv_bias//2,
+            bias=conv_bias,
             kernel_size=d_conv,
             groups=self.d_inner//2,
             **factory_kwargs,

--- a/semantic_segmentation/tools/mamba_vision.py
+++ b/semantic_segmentation/tools/mamba_vision.py
@@ -349,7 +349,7 @@ class MambaVisionMixer(nn.Module):
         dt_init="random",
         dt_scale=1.0,
         dt_init_floor=1e-4,
-        conv_bias=True,
+        conv_bias=False,
         bias=False,
         use_fast_path=True, 
         layer_idx=None,
@@ -400,7 +400,7 @@ class MambaVisionMixer(nn.Module):
         self.conv1d_x = nn.Conv1d(
             in_channels=self.d_inner//2,
             out_channels=self.d_inner//2,
-            bias=conv_bias//2,
+            bias=conv_bias,
             kernel_size=d_conv,
             groups=self.d_inner//2,
             **factory_kwargs,
@@ -408,7 +408,7 @@ class MambaVisionMixer(nn.Module):
         self.conv1d_z = nn.Conv1d(
             in_channels=self.d_inner//2,
             out_channels=self.d_inner//2,
-            bias=conv_bias//2,
+            bias=conv_bias,
             kernel_size=d_conv,
             groups=self.d_inner//2,
             **factory_kwargs,


### PR DESCRIPTION
Hello,

In `conv1d_x` and `conv1d_z`, the bias argument was previously set as `bias=conv_bias//2`. Since `conv_bias` is a boolean, integer division always evaluates this to `False`, regardless of the default value. This has been corrected to `bias=conv_bias`.

However, since the released checkpoints were built with the bugged behaviour (i.e., `bias=conv_bias//2`), updating the default would break compatibility with those checkpoints. To maintain compatibility, the class default has been changed from `conv_bias=True` to `conv_bias=False`.